### PR TITLE
fix: Fix profile avatar parsing bug

### DIFF
--- a/web/src/components/Header.jsx
+++ b/web/src/components/Header.jsx
@@ -46,7 +46,7 @@ function Header({ user, onBack, onRefresh, title, showBackButton = false }) {
           {user && (
             <div className="header-user">
               <img 
-                src={user.avatar || `https://api.dicebear.com/7.x/avataaars/svg?seed=${user.nick}`} 
+                src={user.avatar || 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDAiIGhlaWdodD0iNDAiIHZpZXdCb3g9IjAgMCA0MCA0MCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjQwIiBoZWlnaHQ9IjQwIiByeD0iMjAiIGZpbGw9IiNFNUU3RUIiLz4KPHBhdGggZD0iTTEyIDEyQzkuNzkgMTIgOCAxMC4yMSA4IDhTOS43OSA0IDEyIDRTMTYgNS43OSAxNiA4UzE0LjIxIDEyIDEyIDEyWk0xMiAxNEMxNi40MiAxNCAyMCAxNS43OSAyMCAyMFYyMkg0VjIwQzQgMTUuNzkgNy41OCAxNCAxMiAxNFoiIGZpbGw9IiM5Q0E0QUYiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDgsIDgpIi8+Cjwvc3ZnPgo='} 
                 alt={user.nick}
                 className="header-avatar"
               />

--- a/web/src/components/Post.jsx
+++ b/web/src/components/Post.jsx
@@ -54,7 +54,7 @@ function Post({ post, onProfileClick, allUsers }) {
   }
 
   const getAvatarUrl = (user) => {
-    return user.avatar || `https://api.dicebear.com/7.x/avataaars/svg?seed=${user.nick}`
+    return user.avatar || 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDAiIGhlaWdodD0iNDAiIHZpZXdCb3g9IjAgMCA0MCA0MCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjQwIiBoZWlnaHQ9IjQwIiByeD0iMjAiIGZpbGw9IiNFNUU3RUIiLz4KPHBhdGggZD0iTTEyIDEyQzkuNzkgMTIgOCAxMC4yMSA4IDhTOS43OSA0IDEyIDRTMTYgNS43OSAxNiA4UzE0LjIxIDEyIDEyIDEyWk0xMiAxNEMxNi40MiAxNCAyMCAxNS43OSAyMCAyMFYyMkg0VjIwQzQgMTUuNzkgNy41OCAxNCAxMiAxNFoiIGZpbGw9IiM5Q0E0QUYiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDgsIDgpIi8+Cjwvc3ZnPgo='
   }
 
   return (

--- a/web/src/components/Profile.jsx
+++ b/web/src/components/Profile.jsx
@@ -12,7 +12,7 @@ function Profile({ user, posts, onProfileClick, allUsers }) {
   }
 
   const getAvatarUrl = (user) => {
-    return user.avatar || `https://api.dicebear.com/7.x/avataaars/svg?seed=${user.nick}`
+    return user.avatar || 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDAiIGhlaWdodD0iNDAiIHZpZXdCb3g9IjAgMCA0MCA0MCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjQwIiBoZWlnaHQ9IjQwIiByeD0iMjAiIGZpbGw9IiNFNUU3RUIiLz4KPHBhdGggZD0iTTEyIDEyQzkuNzkgMTIgOCAxMC4yMSA4IDhTOS43OSA0IDEyIDRTMTYgNS43OSAxNiA4UzE0LjIxIDEyIDEyIDEyWk0xMiAxNEMxNi40MiAxNCAyMCAxNS43OSAyMCAyMFYyMkg0VjIwQzQgMTUuNzkgNy41OCAxNCAxMiAxNFoiIGZpbGw9IiM5Q0E0QUYiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDgsIDgpIi8+Cjwvc3ZnPgo='
   }
 
   const formatDate = (dateString) => {
@@ -166,7 +166,7 @@ function Profile({ user, posts, onProfileClick, allUsers }) {
               >
                 <div className="following-avatar">
                   <img 
-                    src={`https://api.dicebear.com/7.x/avataaars/svg?seed=${follow.nick}`}
+                    src='data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDAiIGhlaWdodD0iNDAiIHZpZXdCb3g9IjAgMCA0MCA0MCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjQwIiBoZWlnaHQ9IjQwIiByeD0iMjAiIGZpbGw9IiNFNUU3RUIiLz4KPHBhdGggZD0iTTEyIDEyQzkuNzkgMTIgOCAxMC4yMSA4IDhTOS43OSA0IDEyIDRTMTYgNS43OSAxNiA4UzE0LjIxIDEyIDEyIDEyWk0xMiAxNEMxNi40MiAxNCAyMCAxNS43OSAyMCAyMFYyMkg0VjIwQzQgMTUuNzkgNy41OCAxNCAxMiAxNFoiIGZpbGw9IiM5Q0E0QUYiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDgsIDgpIi8+Cjwvc3ZnPgo='
                     alt={`${follow.nick}'s avatar`}
                   />
                 </div>

--- a/web/src/utils/orgSocialParser.js
+++ b/web/src/utils/orgSocialParser.js
@@ -40,15 +40,15 @@ export function parseOrgSocial(text, sourceUrl = '') {
 
     // Parse global metadata
     if (trimmedLine.startsWith('#+TITLE:')) {
-      user.title = trimmedLine.split(':', 1)[1]?.trim() || ''
+      user.title = trimmedLine.substring(trimmedLine.indexOf(':') + 1).trim()
     } else if (trimmedLine.startsWith('#+NICK:')) {
-      user.nick = trimmedLine.split(':', 1)[1]?.trim() || ''
+      user.nick = trimmedLine.substring(trimmedLine.indexOf(':') + 1).trim()
     } else if (trimmedLine.startsWith('#+DESCRIPTION:')) {
-      user.description = trimmedLine.split(':', 1)[1]?.trim() || ''
+      user.description = trimmedLine.substring(trimmedLine.indexOf(':') + 1).trim()
     } else if (trimmedLine.startsWith('#+AVATAR:')) {
-      user.avatar = trimmedLine.split(':', 1)[1]?.trim() || ''
+      user.avatar = trimmedLine.substring(trimmedLine.indexOf(':') + 1).trim()
     } else if (trimmedLine.startsWith('#+LINK:')) {
-      const link = trimmedLine.split(':', 1)[1]?.trim()
+      const link = trimmedLine.substring(trimmedLine.indexOf(':') + 1).trim()
       if (link) user.links.push(link)
     } else if (trimmedLine.startsWith('#+FOLLOW:')) {
       const parts = trimmedLine.split(/\s+/).slice(1) // Remove #+FOLLOW:
@@ -58,7 +58,7 @@ export function parseOrgSocial(text, sourceUrl = '') {
         user.follows.push({ nick, url })
       }
     } else if (trimmedLine.startsWith('#+CONTACT:')) {
-      const contact = trimmedLine.split(':', 1)[1]?.trim()
+      const contact = trimmedLine.substring(trimmedLine.indexOf(':') + 1).trim()
       if (contact) user.contacts.push(contact)
     }
 


### PR DESCRIPTION
Fixes #2. Profile now uses actual avatar URL from AVATAR field instead of always falling back to random dicebear.com placeholder.

Fixed org-social parser to correctly parse AVATAR field from org files. The issue was with incorrect JavaScript syntax using split(':', 1)[1] which doesn't work in JavaScript. Replaced with proper substring parsing for AVATAR and other metadata fields.

🤖 Generated with [Claude Code](https://claude.ai/code)