### PR TITLE
fix: Fix Posts header indentation on profile page

### DIFF
--- a/web/src/components/Profile.css
+++ b/web/src/components/Profile.css
@@ -204,6 +204,7 @@
 
 .profile-posts {
   margin-bottom: 2rem;
+  padding: 0 1rem;
 }
 
 .posts-list {


### PR DESCRIPTION
## Summary

Fixes #6 - Fixed the indentation issue with the "Posts" header on profile pages.

## Changes Made

- Added missing padding to `.profile-posts` class in `Profile.css`

## Before

The "Posts" header was flush against the left edge, creating inconsistent spacing compared to the "Following" header.

## After

The "Posts" header now has proper indentation matching the "Following" header, creating a consistent visual layout.

🤖 Generated with [Claude Code](https://claude.ai/code)