### PR TITLE
fix: Fix posts ordering to display newest first

### DIFF
--- a/web/src/components/MainApp.jsx
+++ b/web/src/components/MainApp.jsx
@@ -57,7 +57,37 @@ function MainApp({ url, onBack }) {
       })
       
       // Sort by timestamp (newest first)
-      posts.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp))
+      
+      // Check if we have any valid dates to sort by
+      const hasValidDates = posts.some(p => {
+        const date = p.parsedDate || new Date(p.timestamp)
+        return !isNaN(date.getTime())
+      })
+      
+      if (hasValidDates) {
+        // Sort by date when we have valid dates
+        posts.sort((a, b) => {
+          const dateA = a.parsedDate || new Date(a.timestamp)
+          const dateB = b.parsedDate || new Date(b.timestamp)
+          
+          const isValidA = !isNaN(dateA.getTime())
+          const isValidB = !isNaN(dateB.getTime())
+          
+          if (!isValidA && !isValidB) {
+            return 0 // Both invalid, maintain order
+          } else if (!isValidA) {
+            return 1 // A invalid, B valid - B comes first
+          } else if (!isValidB) {
+            return -1 // A valid, B invalid - A comes first
+          } else {
+            return dateB.getTime() - dateA.getTime() // Both valid, newest first
+          }
+        })
+      } else {
+        // No valid dates - assume posts are in chronological order (oldest first)
+        // and reverse them to get reverse chronological order (newest first)
+        posts.reverse()
+      }
       
       setAllPosts(posts)
       

--- a/web/src/components/Profile.jsx
+++ b/web/src/components/Profile.jsx
@@ -1,4 +1,5 @@
 import { motion } from 'framer-motion'
+import { parseOrgSocialTimestamp } from '../utils/orgSocialParser'
 import Post from './Post'
 import './Profile.css'
 
@@ -17,11 +18,16 @@ function Profile({ user, posts, onProfileClick, allUsers }) {
 
   const formatDate = (dateString) => {
     try {
-      return new Date(dateString).toLocaleDateString('en-US', {
+      const date = parseOrgSocialTimestamp(dateString) || new Date(dateString)
+      if (!date || isNaN(date.getTime())) {
+        return 'Date unknown'
+      }
+      return date.toLocaleDateString('en-US', {
         year: 'numeric',
         month: 'long'
       })
-    } catch {
+    } catch (error) {
+      console.warn('Error formatting date:', dateString, error)
       return 'Date unknown'
     }
   }


### PR DESCRIPTION
## Summary

Fixes #8 - Posts are now properly ordered in reverse chronological order (newest first) instead of chronological order (oldest first).

## Changes Made

- **Enhanced sorting logic** in `MainApp.jsx` to handle both valid and invalid date scenarios
- **Robust fallback mechanism** that reverses post order when dates are invalid
- **Maintains compatibility** with future date parsing improvements

## Technical Details

The fix implements intelligent sorting logic that:
1. **Checks for valid dates first** - Uses parsed date objects when available for accurate sorting
2. **Graceful fallback** - When no valid dates exist, reverses the original parse order (oldest→newest becomes newest→oldest)
3. **Mixed scenario handling** - Properly sorts when some posts have valid dates and others don't

## Before

Posts appeared in chronological order (oldest first):
1. "I have written a first version of the client..." (oldest)
2. "To my surprise, Org social is attracting..." 
3. "🎉 Emacs 30.2 is here"
4. "Hello Org-social." (newest)

## After

Posts now appear in reverse chronological order (newest first):
1. "Hello Org-social." (newest)
2. "🎉 Emacs 30.2 is here"
3. "To my surprise, Org social is attracting..."
4. "I have written a first version of the client..." (oldest)

## Test Plan

- [x] Tested with current org-social data showing invalid dates
- [x] Verified posts now appear in reverse chronological order
- [x] Confirmed sorting logic handles both valid and invalid date scenarios
- [x] Ensured no regressions in post display or functionality

🤖 Generated with [Claude Code](https://claude.ai/code)