### PR TITLE
fix: hyperlinks to navigate properly

### DIFF
--- a/lib/org-social-parser-js/src/index.js
+++ b/lib/org-social-parser-js/src/index.js
@@ -678,26 +678,82 @@ function extractLinks(content) {
 }
 
 /**
+ * Normalize URL by adding protocol if missing
+ */
+function normalizeUrl(url) {
+  if (!url) return url
+  
+  // If URL already has a protocol, return as-is
+  if (url.match(/^https?:\/\//)) {
+    return url
+  }
+  
+  // If URL looks like a domain (contains dots but no slashes at start), add https://
+  if (url.match(/^[a-zA-Z0-9][a-zA-Z0-9.-]*\.[a-zA-Z]{2,}/)) {
+    return `https://${url}`
+  }
+  
+  // If URL starts with www., add https://
+  if (url.startsWith('www.')) {
+    return `https://${url}`
+  }
+  
+  // For other cases (like relative URLs), return as-is
+  return url
+}
+
+/**
  * Process org content for display
  */
 function processOrgContent(content) {
   let processed = content
+  
+  // Store all HTML elements (links and mentions) temporarily to avoid interference
+  const htmlElements = []
 
-  // Convert org-mode formatting to HTML-like markup for display
-  processed = processed.replace(/\*([^*]+)\*/g, '<strong>$1</strong>')
-  processed = processed.replace(/\/([^/]+)\//g, '<em>$1</em>')
-  processed = processed.replace(/~([^~]+)~/g, '<code>$1</code>')
-
-  // Links
+  // Process links FIRST - handle org-mode link format [[url][text]]
   processed = processed.replace(/\[\[([^\]]+)\]\[([^\]]+)\]\]/g, (match, url, text) => {
+    let element
     if (url.startsWith('org-social:')) {
-      return `<span class="mention" data-url="${url.substring(11)}">@${text}</span>`
+      element = `<span class="mention" data-url="${url.substring(11)}">@${text}</span>`
+    } else {
+      // Normalize the URL to ensure it has a proper protocol
+      const normalizedUrl = normalizeUrl(url)
+      element = `<a href="${normalizedUrl}" target="_blank" rel="noopener noreferrer">${text}</a>`
     }
-    return `<a href="${url}" target="_blank" rel="noopener noreferrer">${text}</a>`
+    
+    const placeholder = `__HTML_ELEMENT_${htmlElements.length}__`
+    htmlElements.push(element)
+    return placeholder
   })
 
-  // Simple URLs
-  processed = processed.replace(/(https?:\/\/[^\s]+)/g, '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>')
+  // Simple URLs - also normalize standalone URLs
+  processed = processed.replace(/(https?:\/\/[^\s]+)/g, (match) => {
+    const element = `<a href="${match}" target="_blank" rel="noopener noreferrer">${match}</a>`
+    const placeholder = `__HTML_ELEMENT_${htmlElements.length}__`
+    htmlElements.push(element)
+    return placeholder
+  })
+  
+  // Handle URLs that might not have protocol (standalone domain names)
+  processed = processed.replace(/\b([a-zA-Z0-9][a-zA-Z0-9.-]*\.[a-zA-Z]{2,}(?:\/[^\s]*)?)\b/g, (match) => {
+    const element = `<a href="${normalizeUrl(match)}" target="_blank" rel="noopener noreferrer">${match}</a>`
+    const placeholder = `__HTML_ELEMENT_${htmlElements.length}__`
+    htmlElements.push(element)
+    return placeholder
+  })
+
+  // NOW process org-mode formatting (after all URLs are protected)
+  processed = processed.replace(/\*([^*]+)\*/g, '<strong>$1</strong>')
+  // Be more careful with italic processing - don't match URLs or single slashes
+  // Use word boundary and make sure we don't match single character surrounded by slashes
+  processed = processed.replace(/\b\/([^\/\s]+)\//g, '<em>$1</em>')
+  processed = processed.replace(/~([^~]+)~/g, '<code>$1</code>')
+
+  // Restore all HTML elements
+  htmlElements.forEach((element, index) => {
+    processed = processed.replace(`__HTML_ELEMENT_${index}__`, element)
+  })
 
   return processed
 }
@@ -809,4 +865,4 @@ export async function fetchFollowedUsers(mainUser, baseUrl = '') {
   return followedUsers
 }
 
-export { parseOrgSocialTimestamp }
+export { parseOrgSocialTimestamp, processOrgContent }

--- a/lib/org-social-parser-js/test/index.test.js
+++ b/lib/org-social-parser-js/test/index.test.js
@@ -1,4 +1,4 @@
-import { parseOrgSocial, parseOrgSocialTimestamp } from '../src/index.js'
+import { parseOrgSocial, parseOrgSocialTimestamp, processOrgContent } from '../src/index.js'
 
 /**
  * Basic test runner (no framework needed)
@@ -171,6 +171,57 @@ Second post.
     // Posts should be sorted newest first
     const timestamps = result.posts.map(p => p.timestamp)
     assertTruthy(new Date(timestamps[0]) > new Date(timestamps[1]), 'Posts should be sorted newest first')
+  })
+
+  // Test processOrgContent for hyperlink fixes
+  test('processOrgContent - org link without protocol gets https prefix', () => {
+    const content = '[[github.com/tanrax/awesome-org-social][awesome project]]'
+    const result = processOrgContent(content)
+    assertTruthy(result.includes('href="https://github.com/tanrax/awesome-org-social"'), 'Should add https:// prefix to domain links')
+    assertTruthy(result.includes('target="_blank"'), 'Should include target="_blank"')
+    assertTruthy(result.includes('rel="noopener noreferrer"'), 'Should include security attributes')
+  })
+
+  test('processOrgContent - org link with protocol remains unchanged', () => {
+    const content = '[[https://github.com/existing-project][project]]'
+    const result = processOrgContent(content)
+    assertTruthy(result.includes('href="https://github.com/existing-project"'), 'Should keep existing https:// protocol')
+  })
+
+  test('processOrgContent - standalone domain gets linked', () => {
+    const content = 'Check out github.com/simon-duchastel for more info'
+    const result = processOrgContent(content)
+    assertTruthy(result.includes('<a href="https://github.com/simon-duchastel"'), 'Should wrap standalone domain in link')
+    assertTruthy(result.includes('target="_blank"'), 'Should include target="_blank" for standalone domains')
+  })
+
+  test('processOrgContent - www domains get https prefix', () => {
+    const content = '[[www.example.com][example site]]'
+    const result = processOrgContent(content)
+    assertTruthy(result.includes('href="https://www.example.com"'), 'Should add https:// prefix to www domains')
+  })
+
+  test('processOrgContent - relative URLs remain unchanged', () => {
+    const content = '[[/local-page][local link]]'
+    const result = processOrgContent(content)
+    assertTruthy(result.includes('href="/local-page"'), 'Should keep relative URLs as-is')
+  })
+
+  test('processOrgContent - org-social mentions not converted to regular links', () => {
+    const content = '[[org-social:/alice-social.org][Alice]]'
+    const result = processOrgContent(content)
+    assertTruthy(result.includes('<span class="mention"'), 'Should convert org-social links to mentions')
+    assertFalsy(result.includes('<a href='), 'Should not create regular links for mentions')
+  })
+
+  test('processOrgContent - mixed content with different link types', () => {
+    const content = 'Visit [[github.com/project][my project]] or [[https://example.com][example]] or plain github.com/other'
+    const result = processOrgContent(content)
+    
+    // Should handle all three types correctly
+    assertTruthy(result.includes('href="https://github.com/project"'), 'Should add protocol to org link')
+    assertTruthy(result.includes('href="https://example.com"'), 'Should preserve existing protocol')
+    assertTruthy(result.includes('href="https://github.com/other"'), 'Should link standalone domain')
   })
 
   // Summary

--- a/web/public/social.org
+++ b/web/public/social.org
@@ -43,6 +43,15 @@ Check out the features:
 
 [[org-social:/alice-social.org][Alice]] Great question! Here's what I think about that topic.
 
+**
+:PROPERTIES:
+:ID: 2024-12-04T11:45:00Z
+:LANG: en
+:TAGS: testing links
+:END:
+
+Testing hyperlink fixes: [[github.com/tanrax/awesome-org-social][awesome org-social project]] and also a standalone domain github.com/simon-duchastel should work now.
+
 * Polls
 
 **


### PR DESCRIPTION
# Summary

Fixes #22 - Hyperlinks now work correctly by adding missing protocols and proper URL handling.

## Problem

Previously, hyperlinks in org-mode format like `[[github.com/tanrax/awesome-org-social][text]]` were treated as relative URLs, causing navigation to `http://localhost:3001/<em>github.com</em>tanrax<em>awesome-org-social` instead of the intended external site. The issue had two parts:
1. Missing protocol detection for domain-only URLs
2. HTML processing order causing formatting interference with URL parsing

## Solution

- **Added URL normalization**: `normalizeUrl()` function automatically adds `https://` protocol to domain names
- **Improved processing order**: Links are processed before other text formatting to prevent interference  
- **Enhanced standalone domain detection**: Plain text domains like `github.com/user` are automatically linked
- **Preserved existing functionality**: URLs with existing protocols and relative URLs remain unchanged

## Before

Clicking `[[github.com/tanrax/awesome-org-social][awesome project]]` navigated to:
```
http://localhost:3001/<em>github.com</em>tanrax<em>awesome-org-social
```

## After  

Same link now correctly navigates to:
```
https://github.com/tanrax/awesome-org-social
```
