### PR TITLE
chore: Fix license

### DIFF
--- a/lib/org-social-parser-js/package.json
+++ b/lib/org-social-parser-js/package.json
@@ -17,5 +17,5 @@
     "parser"
   ],
   "author": "",
-  "license": "ISC"
+  "license": "MIT"
 }


### PR DESCRIPTION
The license should be MIT everywhere, it was ISC in one place.