### PR TITLE
Fix: Preserve newlines and paragraphs in formatted text

### DIFF
--- a/lib/org-social-parser-js/src/index.js
+++ b/lib/org-social-parser-js/src/index.js
@@ -766,6 +766,16 @@ function processOrgContent(content) {
   processed = processed.replace(/\b\/([^\/\s]+)\//g, '<em>$1</em>')
   processed = processed.replace(/~([^~]+)~/g, '<code>$1</code>')
 
+  // Process newlines and paragraphs AFTER formatting to preserve paragraph structure
+  // Convert double newlines to paragraph breaks
+  processed = processed.replace(/\n\n+/g, '</p><p>')
+  // Convert single newlines to line breaks
+  processed = processed.replace(/\n/g, '<br>')
+  // Wrap content in paragraph tags if it contains paragraph breaks
+  if (processed.includes('</p><p>')) {
+    processed = '<p>' + processed + '</p>'
+  }
+
   // Restore all HTML elements
   htmlElements.forEach((element, index) => {
     processed = processed.replace(`__HTML_ELEMENT_${index}__`, element)

--- a/lib/org-social-parser-js/test/index.test.js
+++ b/lib/org-social-parser-js/test/index.test.js
@@ -529,3 +529,52 @@ describe('formatJoinDate', () => {
     expect(formatJoinDate(new Date('invalid'))).toBe('Recently')
   })
 })
+
+describe('newline and paragraph handling', () => {
+  test('single newlines become line breaks', () => {
+    const content = 'First line\nSecond line\nThird line'
+    const result = processOrgContent(content)
+    expect(result).toContain('First line<br>Second line<br>Third line')
+  })
+
+  test('double newlines become paragraph breaks', () => {
+    const content = 'First paragraph\n\nSecond paragraph\n\nThird paragraph'
+    const result = processOrgContent(content)
+    expect(result).toContain('<p>First paragraph</p><p>Second paragraph</p><p>Third paragraph</p>')
+  })
+
+  test('mixed newlines and paragraphs', () => {
+    const content = 'Line 1\nLine 2\n\nNew paragraph\nAnother line'
+    const result = processOrgContent(content)
+    expect(result).toContain('<p>Line 1<br>Line 2</p><p>New paragraph<br>Another line</p>')
+  })
+
+  test('formatting preserved with newlines', () => {
+    const content = '*Bold text*\nWith newline\n\n~code text~\nAnother line'
+    const result = processOrgContent(content)
+    expect(result).toContain('<strong>Bold text</strong>')
+    expect(result).toContain('<code>code text</code>')
+    expect(result).toContain('<br>')
+    expect(result).toContain('</p><p>')
+  })
+
+  test('code blocks preserve structure', () => {
+    const content = 'Text before\n\n~code block~\n\nText after'
+    const result = processOrgContent(content)
+    expect(result).toContain('<code>code block</code>')
+    expect(result).toContain('<p>Text before</p><p><code>code block</code></p><p>Text after</p>')
+  })
+
+  test('multiple consecutive newlines collapse to single paragraph break', () => {
+    const content = 'Paragraph 1\n\n\n\nParagraph 2'
+    const result = processOrgContent(content)
+    expect(result).toBe('<p>Paragraph 1</p><p>Paragraph 2</p>')
+  })
+
+  test('content without paragraph breaks stays unwrapped', () => {
+    const content = 'Single line\nwith break'
+    const result = processOrgContent(content)
+    expect(result).toBe('Single line<br>with break')
+    expect(result).not.toContain('<p>')
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes newline handling in text formatting to preserve paragraph structure
- Converts double newlines to paragraph breaks and single newlines to line breaks
- Processes newlines after text formatting to maintain proper HTML structure

<img width="587" height="539" alt="Screenshot 2025-08-29 at 12 08 38 PM" src="https://github.com/user-attachments/assets/895ca3f7-9a9d-428f-bc73-503c4228b4f3" />


🤖 Generated with [Claude Code](https://claude.ai/code)